### PR TITLE
#9 Add type-ahead support for MultiSelect component

### DIFF
--- a/src/components/addPhoto/AddPhotoScreen/index.js
+++ b/src/components/addPhoto/AddPhotoScreen/index.js
@@ -366,6 +366,7 @@ class AddPhotoScreen extends React.Component {
                   <Spinner style={[styles.input, styles.spinner]} size="small" />
                 ) : (
                   <MultiSelect
+                    filterable
                     style={styles.input}
                     items={team ? team.members.slice() : []}
                     selectedItems={taggedPeople}

--- a/src/components/app/AppScreen.js
+++ b/src/components/app/AppScreen.js
@@ -8,6 +8,7 @@ const AppScreen = {
   Help: 'Help',
   Feedback: 'Feedback',
   EditLocations: 'EditLocations',
+  Test: 'Test',
 };
 
 export default AppScreen;

--- a/src/components/app/Navigation.js
+++ b/src/components/app/Navigation.js
@@ -7,6 +7,7 @@ import AddPhotoScreen from 'src/components/addPhoto/AddPhotoScreen';
 import HelpScreen from 'src/components/help/HelpScreen';
 import FeedbackScreen from 'src/components/help/FeedbackScreen';
 import EditLocationsScreen from 'src/components/settings/EditLocationsScreen';
+import TestScreen from 'src/components/dev/TestScreen';
 import AppScreen from './AppScreen';
 
 const AppStack = createStackNavigator(
@@ -18,6 +19,7 @@ const AppStack = createStackNavigator(
     [AppScreen.Feedback]: FeedbackScreen,
     [AppScreen.AddPhoto]: AddPhotoScreen,
     [AppScreen.EditLocations]: EditLocationsScreen,
+    [AppScreen.Test]: TestScreen,
   },
   {
     navigationOptions: {
@@ -31,6 +33,7 @@ export default createSwitchNavigator(
   {
     [AppScreen.App]: AppStack,
     [AppScreen.Login]: LoginScreen,
+    [AppScreen.Test]: TestScreen,
   },
   {
     initialRouteName: AppScreen.Login,

--- a/src/components/common/Select/Select.js
+++ b/src/components/common/Select/Select.js
@@ -8,7 +8,6 @@ import {
   Text,
   ListItem,
   Container,
-  Header,
   Title,
   Content,
   Body,
@@ -20,6 +19,7 @@ import {
 import baseStyles from 'src/assets/style';
 import Copy from 'src/assets/Copy';
 import NonIdealState from 'src/components/common/NonIdealState';
+import { filterItems } from './SelectUtil';
 import styles from './style';
 
 class Select extends React.Component {
@@ -109,16 +109,16 @@ class Select extends React.Component {
     const { isModalOpen, filter } = this.state;
     const renderSelected = renderSelectedItem || this.renderSelectedItem;
 
-    const filterItems = allItems => {
+    const filtered = allItems => {
       if (filter) {
-        const filterRegExp = RegExp(filter, 'i');
-        return allItems.filter(item => filterRegExp.test(item[displayKey]));
+        return filterItems(filter, allItems, displayKey);
       }
       return allItems;
     };
 
     const ListComponent = isSectioned ? SectionList : FlatList;
     const listProps = {
+      keyboardShouldPersistTaps: 'always',
       extraData: selectedItem,
       keyExtractor: this.keyExtractor,
       renderItem: this.renderItem,
@@ -140,7 +140,7 @@ class Select extends React.Component {
       listProps.sections = reduce(
         items,
         (acc, item) => {
-          const filteredItems = filterItems(item.data);
+          const filteredItems = filtered(item.data);
           if (filteredItems.length) {
             acc.push({ ...item, data: filteredItems });
           }
@@ -150,7 +150,7 @@ class Select extends React.Component {
       );
       listProps.renderSectionHeader = renderSectionHeader || this.renderSectionHeader;
     } else {
-      listProps.data = filterItems(items);
+      listProps.data = filtered(items);
     }
 
     return (
@@ -161,7 +161,7 @@ class Select extends React.Component {
         <Icon type="FontAwesome" name="caret-down" style={styles.icon} />
         <Modal animationType="slide" visible={isModalOpen} onRequestClose={this.closeModal}>
           <Container>
-            <View style={[baseStyles.manualHeader, styles.header]}> 
+            <View style={[baseStyles.manualHeader, styles.header]}>
               <Body style={baseStyles.headerBody}>
                 <Title>{modalHeader}</Title>
               </Body>

--- a/src/components/common/Select/SelectUtil.js
+++ b/src/components/common/Select/SelectUtil.js
@@ -1,0 +1,4 @@
+export const filterItems = (filter, allItems, displayKey) => {
+  const filterRegExp = RegExp(filter, 'i');
+  return allItems.filter(item => filterRegExp.test(item[displayKey]));
+};

--- a/src/components/dev/TestScreen/index.js
+++ b/src/components/dev/TestScreen/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Container, Header, Title, Content, Left, Body, Right, Text } from 'native-base';
+import AdroitScreen from 'src/components/common/AdroitScreen';
+import BackButton from 'src/components/common/BackButton';
+import baseStyles from 'src/assets/style';
+
+export default class TestScreen extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <AdroitScreen>
+        <Container>
+          <Header>
+            <Left style={baseStyles.headerLeft}>
+              <BackButton />
+            </Left>
+            <Body style={baseStyles.headerBody}>
+              <Title>Test</Title>
+            </Body>
+            <Right style={baseStyles.headerRight} />
+          </Header>
+          <Content padder>
+            <Text>Test page</Text>
+          </Content>
+        </Container>
+      </AdroitScreen>
+    );
+  }
+}

--- a/src/components/dev/TestScreen/style.js
+++ b/src/components/dev/TestScreen/style.js
@@ -1,0 +1,4 @@
+import { StyleSheet } from 'react-native';
+// import Theme, { GridSize } from 'src/assets/theme';
+
+export default StyleSheet.create({});


### PR DESCRIPTION
Ref: #9 

`MultiSelect` now uses the same structure as the existing filterable `Select` component. 

If the `filterable` prop is set (to `true`), the list will be filterable by typing in the search box at the top of the modal. 

The new `filterPlaceholder` prop determines the placeholder text for the search box (defaults to `Search...`).

By new `clearFilterOnToggleItem` prop determines whether the filter text will be cleared (and the keyboard dismissed) when an item is toggled (defaults to `true`).